### PR TITLE
Remove ChatFrame.alternativeDefaultLanguage

### DIFF
--- a/ElvUI/Core/Modules/Chat/Chat.lua
+++ b/ElvUI/Core/Modules/Chat/Chat.lua
@@ -1541,11 +1541,8 @@ function CH:MessageFormatter(frame, info, chatType, chatGroup, chatTarget, chann
 
 	local playerLink
 	local playerLinkDisplayText = coloredName
-	local relevantDefaultLanguage = frame.defaultLanguage
-	if chatType == 'SAY' or chatType == 'YELL' then
-		relevantDefaultLanguage = frame.alternativeDefaultLanguage
-	end
-	local usingDifferentLanguage = (arg3 ~= '') and (arg3 ~= relevantDefaultLanguage)
+
+	local usingDifferentLanguage = (arg3 ~= '') and (arg3 ~= frame.defaultLanguage)
 	local usingEmote = (chatType == 'EMOTE') or (chatType == 'TEXT_EMOTE')
 
 	if usingDifferentLanguage or not usingEmote then


### PR DESCRIPTION
ChatFrame Interface of 3.3.5 client has only defaultLanguage. The alternativeDefaultLanguage is introduced later and is not part of 3.3.5 API. (There is no feature of changing speaking language in WOTLK ).
The alternativeDefaultLanguage therefore will be always nil which makes say/yell messages have prefix [Common] or [Orcish] even  if player is part of that faction.

