### PR TITLE
Fix: Instance difficulty button not showing on minimap

### DIFF
--- a/ElvUI/Core/Modules/Maps/Minimap.lua
+++ b/ElvUI/Core/Modules/Maps/Minimap.lua
@@ -327,7 +327,10 @@ function M:UpdateIcons()
 		if gameTime then M:SaveIconParent(gameTime) end
 		if mailFrame then M:SaveIconParent(mailFrame) end
 		if battlefieldFrame then M:SaveIconParent(battlefieldFrame) end
-		if difficulty then M:SaveIconParent(difficulty) end
+		if difficulty then
+			difficulty:SetParent(Minimap)
+			M:SaveIconParent(difficulty)
+		end
 		if lfgFrame then M:SaveIconParent(lfgFrame) end
 	end
 


### PR DESCRIPTION
Global variable MiniMapInstanceDifficulty has MinimapCluster parent instead of Minimap like all other icons.
WOTLK/Elvui addresses this by setting it's parent to Minimap. 

